### PR TITLE
fix: preventing multi operations from being applied twice

### DIFF
--- a/lib/duct/multi.ex
+++ b/lib/duct/multi.ex
@@ -85,7 +85,7 @@ defmodule Duct.Multi do
   @doc false
   def __apply__(%__MODULE__{operations: operations}) do
     operations
-    |> Enum.reverse(operations)
+    |> Enum.reverse()
     |> Enum.reduce(%{}, &apply_operation/2)
     |> case do
       {name, value, acc} -> {:error, name, value, acc}


### PR DESCRIPTION
This pull request aims to prevent `Duct.Multi` operations from being applied twice.

The code

```elixir
operations |> Enum.reverse(operations)
```

reverses the elements in operations and append the non-reversed operations elements into the reversed list.

This concatenation appears not to be necessary. So I replaced [Enum.reverse/2](https://hexdocs.pm/elixir/Enum.html#reverse/2) with [Enum.reverse/1](https://hexdocs.pm/elixir/Enum.html#reverse/1), which just reverses the operations list.